### PR TITLE
Add use for capture function

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -6,6 +6,7 @@ use Castor\Attribute\AsTask;
 use Castor\GlobalHelper;
 use Symfony\Component\Console\Question\Question;
 
+use function Castor\capture;
 use function Castor\fs;
 use function Castor\io;
 use function Castor\run;


### PR DESCRIPTION
There is a missing `use` for the `capture` function