### PR TITLE
fix(phpstan): Fix deprecated config and lower the level from max to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You will need :
 
 Then you can : 
 
-- Use this template project as a new project in Github.
+- Use this template project as a new project in GitHub.
 - Clone your project and run `castor local:setup` inside it.
 - Clean the castor files if you don't want them in your project with `castor local:clean-up`.
 - Remove the `composer.lock` line in `apps/sylius/.gitignore` if you want to commit it.

--- a/dist/sylius/phpstan.neon
+++ b/dist/sylius/phpstan.neon
@@ -1,10 +1,10 @@
 parameters:
-    level: max
+    level: 8
     paths:
-        - %rootDir%/src/
-
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
+        - src/
+        - plugins/
 
     ignoreErrors:
         - '/Generator expects value type Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface\, object given\./'
+#        - identifier: missingType.iterableValue
+#        - identifier: missingType.generics

--- a/resources/makefiles/testing.mk
+++ b/resources/makefiles/testing.mk
@@ -8,7 +8,7 @@ test.composer: ## Validate composer.json
 	$(call symfony.composer,validate --strict)
 
 test.phpstan: ## Run PHPStan
-	${PHPSTAN} analyse -c phpstan.neon src/ plugins/
+	${PHPSTAN} analyse -c phpstan.neon
 
 test.phpunit: ## Run PHPUnit
 	${PHPUNIT}


### PR DESCRIPTION
- Lower level from `max` to `8`. As explained [here](https://phpstan.org/user-guide/rule-levels) (and as [PHPStan itself](https://github.com/phpstan/phpstan-src/blob/2.0.x/build/phpstan.neon#L14) doesn't use the `max` level), the `max` (== `9`) level is only about being strict with `mixed` type, which can be annoying when we need to extend classes from dependencies.

- Fixed deprecated config to avoid those warnings (commented by default to avoid instant failing PHPStan analyse on a fresh setup)

```
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
	ignoreErrors:
		-
			identifier: missingType.iterableValue

⚠️  You're using a deprecated config option checkGenericClassInNonGenericObjectType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing generic typehints.

If you want to continue ignoring missing typehints from generics,
add missingType.generics error identifier to your ignoreErrors:

parameters:
	ignoreErrors:
		-
			identifier: missingType.generics
```